### PR TITLE
Enable project name in URL query string

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -445,6 +445,15 @@ img {
   margin: 0.5rem;
 }
 
+.soft-error {
+  background-color: rgb(255, 218, 183);
+  border-radius: 10px;
+  font-size: 1.1rem;
+  padding: 0.33rem 0.5rem;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
 .project {
   background-color: #f0f0f0;
   color: #8a8a8a;

--- a/css/style.scss
+++ b/css/style.scss
@@ -434,6 +434,15 @@ img {
   }
 }
 
+.soft-error {
+  background-color: rgb(255, 218, 183);
+  border-radius: 10px;
+  font-size: 1.1rem;
+  padding: 0.33rem 0.5rem;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
 .project {
   background-color: colors('light');
   color: colors('medium');

--- a/index.html
+++ b/index.html
@@ -93,7 +93,10 @@
 	</div>
 	<section class="projects sub-container">
 		<a name="projects-section"></a>
-		<div class="projects-list">
+		<div class="projects-list" id="projects-list-prose">
+			<div class="soft-error" id="project-not-found-notification">
+				<p>It looks like the project in the URL, <span id="project-query-attempted"></span>, wasn't found in the project list!</p>
+			</div>
 			<p>Choose a project to preview:</p>
 			<div class="sort-type">
 				<button id="sortByCategory">Filter By Category</button>

--- a/js/script.js
+++ b/js/script.js
@@ -39,9 +39,35 @@ window.addEventListener('load', function(){
       categoryListProjectsHTML = listToHTML(categoryList, false);
       tagListProjectsHTML = listToHTML(tagList, false);
     })
-    .then(() => {
-      showAllProjects();
-    });
+    .then(showAllProjects)
+    .then(checkProjectInUrl);
+
+  function checkProjectInUrl() {
+      // If the user navigated here from a URL referencing a specific project,
+      // load the project and scroll to it. Sanitize the query parameter!
+      let projectUrlParamQueryString = window.location.search;
+      let projectUrlParam = new URLSearchParams(projectUrlParamQueryString);
+      let urlNavigatedProject = projectUrlParam.get('project') || '';
+      let sanitizedQuery = encodeURI(urlNavigatedProject);
+      if (sanitizedQuery && nameList[sanitizedQuery]) {
+        hideProjectError();
+        projectSelectElement.val(sanitizedQuery);
+        projectSelectElement.trigger('change');
+      } else {
+        showProjectError(sanitizedQuery);
+      }
+  }
+
+  function hideProjectError() {
+    $('#project-not-found-notification').hide();
+    $('#project-query-attempted').text('');
+  }
+
+  function showProjectError(attemptedProject) {
+    $('#project-not-found-notification').show();
+    $('#project-query-attempted').html(`<pre><code>${attemptedProject}</code></pre>`);
+    softScrollTo('#projects-list-prose', 0, 400);
+  }
 
   // helper function for gathering project names
   function populateNameObj(projectList) {
@@ -63,7 +89,7 @@ window.addEventListener('load', function(){
     }
   }
 
-  // helper function for gathering categories; slightly different, since the tags are arrays, where the category is a single item
+  // helper function for gathering tags; slightly different, since the tags are arrays, where the category is a single item
   function populateTagObj(projectList) {
     for (projName in projectList) {
       let p = projectList[projName];
@@ -187,6 +213,8 @@ window.addEventListener('load', function(){
     projectElements.descriptionText.innerHTML = convertMarkdownToHtml(project.descriptionText);
     projectElements.gitHubUrl.innerText = gitHubUrl;
     projectElements.gitHubUrl.href = gitHubUrl;
+
+    hideProjectError();
     
     softScrollTo('#projectName', 0, 400);
   }
@@ -343,6 +371,10 @@ window.addEventListener('load', function(){
       allEls[i].style.backgroundSize = "auto 100%";
     }
   }
+  
+  ////////////////////////////////////
+  //          End load event        //
+  ////////////////////////////////////
 });
 
 ////////////////////////////////////


### PR DESCRIPTION
# Summary

This set of changes enables project names present in the GitHub pages URL to load the named project in the **Projects** section automatically, in addition to scrolling the user to the section. An error dialog is displayed if the project name isn't found in the project list.

Sanitization is performed on the URL query string before manipulating it in code.

## Example: Valid Project Name Found

1. The user visits `carvacodes.github.io/?project=particle-explosions` (`/` before the question mark `?` can optionally be omitted).
2. The project is loaded into the project viewer `iframe` on load (at the end of a `Promise` chain), its relevant data is loaded onto the page, and the user is scrolled to the **Projects** section automatically:

![image](https://github.com/user-attachments/assets/7b06e428-c177-4c09-b6a4-74f3a136c86e)

## Example: Project Name Not Found

1. The user visits `carvacodes.github.io?project=emulating-pixeliza` (`z` in the second word should be an `s` to match a valid project).
2. An error dialog is populated with the project name that was found, the dialog is un-hidden on the page, and the user is scrolled to the error dialog:

![image](https://github.com/user-attachments/assets/42b61926-53ab-4cc6-861f-0e4634360ab9)

> The screenshot above shows the local server IP in place of the real-world domain.
